### PR TITLE
feat: enable multiple warehouse usage of repo

### DIFF
--- a/macros/date_add_cross_db.sql
+++ b/macros/date_add_cross_db.sql
@@ -1,0 +1,9 @@
+{% macro date_add_cross_db(date_column, days) %}
+  {% if target.type == 'postgres' %}
+    {{ date_column }} + interval '{{ days }} days'
+  {% elif target.type == 'bigquery' %}
+    date_add({{ date_column }}, interval {{ days }} day)
+  {% else %}
+    {{ date_column }} + interval {{ days }} day
+  {% endif %}
+{% endmacro %}

--- a/models/deals.sql
+++ b/models/deals.sql
@@ -6,6 +6,9 @@ select
     plan,
     seats,
     amount,
-    date(created_date) as created_date
+    -- this code keeps the date fields relevant for the demo environment
+    -- it adds the difference between the current date and a fixed date (2025-01-01)
+    -- to the original date fields, effectively shifting them into the future
+    {{ date_add_cross_db('created_date', 'date_diff(current_date(), \'2025-01-01\', day)') }} as created_date
 from 
     {{ ref('deals_raw') }}

--- a/models/deals.yml
+++ b/models/deals.yml
@@ -184,8 +184,3 @@ models:
           dimension:
             type: date
             time_intervals: ['DAY', 'WEEK', 'MONTH', 'MONTH_NAME', 'YEAR', 'QUARTER']
-            sql: >
-              date_add(
-                ${TABLE}.created_date,
-                interval date_diff(current_date(), '2025-01-01', day) day
-              )

--- a/models/tracks.sql
+++ b/models/tracks.sql
@@ -3,7 +3,10 @@ select
     t.user_id,
     t.event_id as id,
     t.event_name as name,
-    t.event_timestamp as timestamp
+    -- this code keeps the date fields relevant for the demo environment
+    -- it adds the difference between the current date and a fixed date (2025-01-01)
+    -- to the original date fields, effectively shifting them into the future
+    {{ date_add_cross_db('t.event_timestamp', 'date_diff(current_date(), \'2025-01-01\', day)') }} as timestamp
 from 
     {{ ref('tracks_raw') }} t
 

--- a/models/tracks.yml
+++ b/models/tracks.yml
@@ -1,7 +1,6 @@
 version: 2
 models:
   - name: tracks
-
     meta:
       required_filters:
         - timestamp: 'inThePast 12 months'
@@ -65,8 +64,3 @@ models:
                 'MONTH_NAME',
                 'QUARTER_NAME'
               ]
-            sql: >
-              timestamp_add(
-                ${TABLE}.timestamp,
-                interval timestamp_diff(current_timestamp(), timestamp '2025-01-01 00:00:00', second) second
-              )

--- a/models/users.sql
+++ b/models/users.sql
@@ -1,17 +1,34 @@
 
+with cleaned_data as (
+    select
+        user_id,
+        account_id,
+        email,
+        job_title,
+        case when is_marketing_opted_in = 1 then true else false end as is_marketing_opted_in,
+        created_at,
+        first_logged_in_at,
+        -- the below cleans synthetically created data
+        case   
+            when latest_logged_in_at < first_logged_in_at then first_logged_in_at
+            when latest_logged_in_at > '2024-12-31 11:52:45' then '2024-12-31 11:52:45'
+            else latest_logged_in_at
+        end as latest_logged_in_at
+    from 
+        {{ ref('users_raw') }}
+)
+
 select
     user_id,
     account_id,
     email,
     job_title,
-    case when is_marketing_opted_in = 1 then true else false end as is_marketing_opted_in,
-    created_at,
-    first_logged_in_at,
-    -- the below cleans synthetically created data
-    case   
-        when latest_logged_in_at < first_logged_in_at then first_logged_in_at
-        when latest_logged_in_at > '2024-12-31 11:52:45' then '2024-12-31 11:52:45'
-        else latest_logged_in_at
-    end as latest_logged_in_at
+    is_marketing_opted_in,
+    -- this code keeps the date fields relevant for the demo environment
+    -- it adds the difference between the current date and a fixed date (2025-01-01)
+    -- to the original date fields, effectively shifting them into the future
+    {{ date_add_cross_db('created_at', 'date_diff(current_date(), \'2025-01-01\', day)') }} as created_at,
+    {{ date_add_cross_db('first_logged_in_at', 'date_diff(current_date(), \'2025-01-01\', day)') }} as first_logged_in_at,
+    {{ date_add_cross_db('latest_logged_in_at', 'date_diff(current_date(), \'2025-01-01\', day)') }} as latest_logged_in_at
 from 
-    {{ ref('users_raw') }}
+    cleaned_data

--- a/models/users.yml
+++ b/models/users.yml
@@ -73,28 +73,13 @@ models:
         meta:
           dimension:
             type: timestamp
-            sql: >
-              timestamp_add(
-                ${TABLE}.created_at,
-                interval timestamp_diff(current_timestamp(), timestamp '2025-01-01 00:00:00', second) second
-              )
       - name: first_logged_in_at
         description: "Timestamp of the first login of the user"
         meta:
           dimension:
             type: timestamp
-            sql: >
-              timestamp_add(
-                ${TABLE}.first_logged_in_at,
-                interval timestamp_diff(current_timestamp(), timestamp '2025-01-01 00:00:00', second) second
-              )
       - name: latest_logged_in_at
         description: "Timestamp showing the latest date that the given user logged in"
         meta:
           dimension:
             type: timestamp
-            sql: >
-              timestamp_add(
-                ${TABLE}.latest_logged_in_at,
-                interval timestamp_diff(current_timestamp(), timestamp '2025-01-01 00:00:00', second) second
-              )


### PR DESCRIPTION
## Summary
Refactored date fast-forward logic from model.yml files to a centralized dbt macro to ensure consistent date handling across SQL runner and Explore interfaces.

### Changes

  - Created `date_add_cross_db macro` in macros/date_add_cross_db.sql with warehouse-specific date arithmetic for BigQuery and PostgreSQL
  - Updated model SQL files (deals.sql, tracks.sql, users.sql) to use the macro for date field transformations
  - Removed warehouse-specific SQL from model.yml files to eliminate duplication and potential inconsistencies
  - Maintained demo environment functionality by preserving the date-shifting logic that keeps data relevant
  - Note I have not applied this fast forward logic to the fanouts models yet. 
 
### Technical Details
  The macro handles date syntax differences between warehouses
  - BigQuery: Uses date_add() function
  - PostgreSQL: Uses + interval syntax
  - Fallback: Default interval syntax for other warehouses

### Testing 
- I have verified that the dates are correct in the resulting models when run on BigQuery. Note that the date will show as different when querying the model now whereas before the logic was on top of the model applied by the yaml. 
Sample code used: 
``` sql 
-- i pointed to lightdash analytics bq project, where I applied the change 
SELECT event_id,
       Date(event_timestamp),
       'after_change_tracks_raw' AS source
FROM   `lightdash-analytics.dbt_jhitchcock.tracks_raw`
WHERE  event_id = '42fdf86b-1376-4930-b8b7-ddd89f886494'
UNION ALL
SELECT id,
       Date(timestamp),
       'after_change_tracks' AS source
FROM   `lightdash-analytics.dbt_jhitchcock.tracks`
WHERE  id = '42fdf86b-1376-4930-b8b7-ddd89f886494'
UNION ALL
-- points to healthcare demo bq project where the change was not applied
SELECT event_id,
       Date(event_timestamp),
       'before_change_tracks_raw' AS source
FROM   `lightdash-healthcare-demo.dbt_jhitchcock.tracks_raw`
WHERE  event_id = '42fdf86b-1376-4930-b8b7-ddd89f886494'
UNION ALL
SELECT id,
       Date(timestamp),
       'before_change_tracks' AS source
FROM   `lightdash-healthcare-demo.dbt_jhitchcock.tracks`
WHERE  id = '42fdf86b-1376-4930-b8b7-ddd89f886494'
ORDER  BY source 
```
- @ZeRego please would you test on the Postgres side 
