### PR TITLE
Fix: Division by 0

### DIFF
--- a/models/demo/deals.yml
+++ b/models/demo/deals.yml
@@ -27,7 +27,7 @@ models:
         type: number
         description: The percentage of deals that have been won
         format: percent
-        sql: ${won_deals} / ${unique_deals}
+        sql: ${won_deals} / NULLIF(${unique_deals}, 0)
         spotlight:
           visibility: show
           categories:
@@ -35,11 +35,11 @@ models:
       loss_rate:
         type: number
         format: percent
-        sql: ${lost_deals} / ${unique_deals}
+        sql: ${lost_deals} / NULLIF(${unique_deals}, 0)
       win_vs_lost_ratio:
         type: number
         round: 2
-        sql: ${lost_deals} / NULLIF(${won_deals})
+        sql: ${lost_deals} / NULLIF(${won_deals}, 0)
 
   columns:
     - name: deal_id

--- a/models/demo/users.yml
+++ b/models/demo/users.yml
@@ -15,7 +15,7 @@ models:
           type: number
           description: The percentage of users that are currently opted in to marketing
           format: percent
-          sql: ${unique_users_with_marketing_opt_in} / ${unique_users}
+          sql: ${unique_users_with_marketing_opt_in} / NULLIF(${unique_users}, 0)
           spotlight:
             visibility: show
             categories:


### PR DESCRIPTION
Change: Adding NULLIF to deals metric `win_vs_lost_ratio`
Rationale: Throws error: invalidQuery - division by zero: 0 / 0 when aggregated by segment or plan

**Not tested - service account in 1P does not have permissions on tables