### PR TITLE
Add arr_band dimension to accounts

### DIFF
--- a/models/demo/accounts.sql
+++ b/models/demo/accounts.sql
@@ -3,7 +3,12 @@ select
     account_id,
     account_name,
     industry,
-    segment, 
-    estimated_annual_recurring_revenue
-from 
+    segment,
+    estimated_annual_recurring_revenue,
+    case
+        when estimated_annual_recurring_revenue < 1000000 then 'Small (< $1M)'
+        when estimated_annual_recurring_revenue < 10000000 then 'Medium ($1M-$10M)'
+        else 'Large ($10M+)'
+    end as arr_band
+from
     {{ ref('accounts_raw') }}

--- a/models/demo/accounts.yml
+++ b/models/demo/accounts.yml
@@ -84,4 +84,10 @@ models:
               label: "Total Estimated ARR"
               description: "Sum of all estimated annual recurring revenue"
               format: 'usd'
+      - name: arr_band
+        description: "Bucketed ARR tier for this account: Small (<$1M), Medium ($1M-$10M), or Large ($10M+)"
+        meta:
+          dimension:
+            type: string
+            label: ARR Band
             


### PR DESCRIPTION
## Summary
- Added a derived `arr_band` column to `models/demo/accounts.sql` that buckets accounts by estimated ARR into Small (<\$1M), Medium (\$1M-\$10M), and Large (\$10M+).
- Exposed it as a string dimension in `models/demo/accounts.yml` with label "ARR Band".

The underlying `estimated_annual_recurring_revenue` dimension is hidden, so this gives a chart-friendly tier grouping that complements `segment` without revealing the raw revenue number.

## Test plan
- [x] `dbt build --select accounts+` rebuilds accounts and downstream models cleanly
- [ ] Confirm `arr_band` shows up as a dimension in the Lightdash preview project for this branch
- [ ] Spot-check a chart grouped by `arr_band` returns the expected three buckets

🤖 Generated with [Claude Code](https://claude.com/claude-code)