### PR TITLE
ci: bump action versions, handle slashed branch names,& skip stop-preview when none exists

### DIFF
--- a/.github/workflows/close-preview.yml
+++ b/.github/workflows/close-preview.yml
@@ -3,15 +3,15 @@ name: close-preview
 
 on:
   pull_request:
-    types: [closed, merged]
+    types: [closed]
 
 jobs:
   preview:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3.4.1
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
 
       - name: Get lightdash version 
         uses: sergeysova/jq-action@v2
@@ -30,5 +30,16 @@ jobs:
           LIGHTDASH_PROJECT: ${{ secrets.LIGHTDASH_PROJECT }}          
           LIGHTDASH_URL: ${{ secrets.LIGHTDASH_URL }}          
 
-        run:  lightdash stop-preview --name ${GITHUB_HEAD_REF##*/}
-
+        run: |
+          PREVIEW_NAME="${GITHUB_HEAD_REF//\//-}"
+          EXISTS=$(curl -sf -H "Authorization: ApiKey ${LIGHTDASH_API_KEY}" \
+            "${LIGHTDASH_URL}/api/v1/org/projects" \
+            | jq -r --arg name "$PREVIEW_NAME" \
+              '.results[] | select(.name == $name and .type == "PREVIEW") | .projectUuid' \
+            | head -n1)
+          if [ -n "$EXISTS" ]; then
+            echo "Preview project '$PREVIEW_NAME' found, stopping it."
+            lightdash stop-preview --name "$PREVIEW_NAME"
+          else
+            echo "No preview project named '$PREVIEW_NAME' found, nothing to do."
+          fi

--- a/.github/workflows/lightdash-compile.yml
+++ b/.github/workflows/lightdash-compile.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3.4.1
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10.x"
 
@@ -26,7 +26,7 @@ jobs:
           GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
         if: "${{ env.GOOGLE_CREDENTIALS != '' }}"
         id: create-json
-        uses: jsdaniell/create-json@1.1.2
+        uses: jsdaniell/create-json@v1.2.3
         with:
           name: "googlecredentials.json"
           json: ${{ env.GOOGLE_CREDENTIALS }}

--- a/.github/workflows/lightdash-deploy.yml
+++ b/.github/workflows/lightdash-deploy.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3.4.1
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.9.x"
 
@@ -24,7 +24,7 @@ jobs:
           GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
         if: "${{ env.GOOGLE_CREDENTIALS != '' }}"
         id: create-json
-        uses: jsdaniell/create-json@1.1.2
+        uses: jsdaniell/create-json@v1.2.3
         with:
           name: "googlecredentials.json"
           json: ${{ env.GOOGLE_CREDENTIALS }}

--- a/.github/workflows/lightdash-validate.yml
+++ b/.github/workflows/lightdash-validate.yml
@@ -18,9 +18,9 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3.4.1
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10.x"
 
@@ -29,7 +29,7 @@ jobs:
           GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
         if: "${{ env.GOOGLE_CREDENTIALS != '' }}"
         id: create-json
-        uses: jsdaniell/create-json@1.1.2
+        uses: jsdaniell/create-json@v1.2.3
         with:
           name: "googlecredentials.json"
           json: ${{ env.GOOGLE_CREDENTIALS }}
@@ -88,7 +88,7 @@ jobs:
 
       - name: Comment validation results on PR
         if: steps.finder.outputs.pr != ''
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           number: ${{ steps.finder.outputs.pr }}
           header: lightdash-validate

--- a/.github/workflows/start-preview.yml
+++ b/.github/workflows/start-preview.yml
@@ -17,9 +17,9 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3.4.1
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10.x"
 
@@ -28,7 +28,7 @@ jobs:
           GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
         if: "${{ env.GOOGLE_CREDENTIALS != '' }}"
         id: create-json
-        uses: jsdaniell/create-json@1.1.2
+        uses: jsdaniell/create-json@v1.2.3
         with:
           name: "googlecredentials.json"
           json: ${{ env.GOOGLE_CREDENTIALS }}
@@ -67,13 +67,15 @@ jobs:
           LIGHTDASH_URL: ${{ secrets.LIGHTDASH_URL }}    
           GOOGLE_APPLICATION_CREDENTIALS: '/tmp/googlecredentials.json'
 
-        run:  lightdash start-preview --project-dir "$PROJECT_DIR" --profiles-dir . --name ${GITHUB_REF##*/}
+        run: |
+          PREVIEW_NAME="${GITHUB_REF_NAME//\//-}"
+          lightdash start-preview --project-dir "$PROJECT_DIR" --profiles-dir . --name "$PREVIEW_NAME"
 
       - uses: jwalton/gh-find-current-pr@v1
         id: finder
         
       - name: Leave a comment after deployment
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           number: ${{ steps.finder.outputs.pr }}
           message: |


### PR DESCRIPTION
- bump action versions (checkout, setup-node, setup-python, create-json, sticky-pull-request-comment)                                                                   
- sanitize branch names with / → - (start and close previews)                                                                                                                     
- skip stop-preview when no preview exists (this stops failures on old PRs that are closed that don't have previews anymore)                                                                                                                        
- drop redundant `merged` trigger from close-preview     