### PR TITLE
Add min won deal amount metric

### DIFF
--- a/models/demo/deals.yml
+++ b/models/demo/deals.yml
@@ -243,3 +243,10 @@ models:
             format: '$#,##0'
             filters:
               - stage: 'Won'
+          min_won_deal_amount:
+            groups: ['Deal Amounts']
+            type: min
+            description: The minimum deal amount for won deals
+            format: '$#,##0'
+            filters:
+              - stage: 'Won'


### PR DESCRIPTION
## Summary
- Adds a `min_won_deal_amount` metric to the deals model, computing the minimum deal amount across won deals (filtered to `stage: 'Won'`).

This complements the existing won-deal amount metrics in the `Deal Amounts` group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)