### PR TITLE
Restore selected_kpi parameter metric on deals model

### DIFF
--- a/models/demo/deals.yml
+++ b/models/demo/deals.yml
@@ -3,6 +3,28 @@ models:
     meta:
       primary_key: deal_id
       description: One row per deal in our CRM. Tracks pipeline stage, plan, seats, and amount.
+      parameters:
+        kpi_selector:
+          label: KPI Metric
+          description: Choose which KPI the Selected KPI metric should display
+          options:
+            - total_revenue
+            - won_revenue
+            - deal_count
+            - win_rate
+          default: total_revenue
+      metrics:
+        selected_kpi:
+          label: Selected KPI
+          description: Dynamic metric that changes based on the KPI Metric parameter selection
+          type: number
+          sql: |
+            CASE
+              WHEN ${lightdash.parameters.kpi_selector} = 'total_revenue' THEN ${deals.total_amount}
+              WHEN ${lightdash.parameters.kpi_selector} = 'won_revenue' THEN ${deals.total_won_amount}
+              WHEN ${lightdash.parameters.kpi_selector} = 'deal_count' THEN ${deals.unique_deals}
+              WHEN ${lightdash.parameters.kpi_selector} = 'win_rate' THEN ${deals.win_rate} * 100
+            END
       joins:
         - join: accounts
           sql_on: ${deals.account_id} = ${accounts.account_id}


### PR DESCRIPTION
## What

Re-implements the `deals_selected_kpi` metric that a chart references but which was missing from the model, causing the error:

> Tried to reference metric with unknown field id: deals_selected_kpi

## Changes

Added to the model-level `meta:` of the `deals` model in `models/demo/deals.yml`:

- **`kpi_selector` parameter** — lets the viewer pick which KPI to display (`total_revenue`, `won_revenue`, `deal_count`, `win_rate`; default `total_revenue`).
- **`selected_kpi` metric** (`deals_selected_kpi`) — a dynamic number metric whose `CASE` switches between existing deals metrics based on the parameter:
  - `total_revenue` → `total_amount`
  - `won_revenue` → `total_won_amount`
  - `deal_count` → `unique_deals`
  - `win_rate` → `win_rate * 100`

All four referenced metrics already exist on the model, so the references resolve cleanly. The definition was restored from the `docs/metrics-parameters-example` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)