### PR TITLE
Restore missing metrics flagged by Lightdash validation

### DIFF
--- a/models/demo/activities.yml
+++ b/models/demo/activities.yml
@@ -17,17 +17,18 @@ models:
           default: "activity_type"
           multiple: false
 
-    metrics:
-      avg_activities_per_lead:
-        type: average
-        description: "Average number of activities per lead"
-        sql: SAFE_DIVIDE(${total_activities}, NULLIF(${lead_id_total_leads},0))
-        groups: ['Activity Performance']
-      demos_held:
-        type: count
-        description: "Total number of demo activities held"
-        sql: CASE WHEN ${activity_type} = 'demo_held' THEN 1 ELSE NULL END
-        groups: ['Activity Performance']
+      metrics:
+        avg_activities_per_lead:
+          type: number
+          description: "Average number of activities per lead"
+          sql: SAFE_DIVIDE(${total_activities}, NULLIF(${lead_id_total_leads},0))
+          format: '0.0'
+          groups: ['Activity Performance']
+        demos_held:
+          type: count
+          description: "Total number of demo activities held"
+          sql: CASE WHEN ${activity_type} = 'demo_held' THEN 1 ELSE NULL END
+          groups: ['Activity Performance']
 
     columns:
       - name: activity_id
@@ -80,23 +81,24 @@ models:
           dimension:
             type: string
             label: Lead ID
-          lead_id_total_leads:
-            label: Total Leads
-            description: 'Count distinct of Lead id on the table Activities '
-            type: count_distinct
-            format: '#,##0.000'
-            filters: []
+          metrics:
+            lead_id_total_leads:
+              label: Total Leads
+              description: 'Count distinct of Lead id on the table Activities '
+              type: count_distinct
+              format: '#,##0.000'
       - name: deal_id
         description: "The deal this activity is associated with"
         meta:
           dimension:
             type: string
             label: Deal ID
-          lead_id_total_leads:
-            label: Total Deals
-            description: 'Count distinct of Lead id on the table Activities '
-            type: count_distinct
-            format: '#,##0.000'
+          metrics:
+            deal_id_total_deals:
+              label: Total Deals
+              description: 'Count distinct of Deal id on the table Activities '
+              type: count_distinct
+              format: '#,##0.000'
       - name: sdr_name
         description: "Sales Development Rep who performed the activity"
         tests:

--- a/models/demo/deals.yml
+++ b/models/demo/deals.yml
@@ -242,6 +242,21 @@ models:
               visibility: show
               categories:
                 - sales
+          total_open_amount:
+            groups: ['Deal Amounts']
+            type: sum
+            description: The sum of deal amount for open deals (not yet Won or Lost)
+            format: '$#,##0'
+            filters:
+              - stage: ['New', 'Qualified', 'PoC', 'Negotiation']
+            ai_hint: |
+              CloseRate Kevin: Use total_open_amount to measure the value of open pipeline (deals still in progress).
+              Track over time to monitor pipeline coverage. Compare against total_won_amount to gauge future revenue potential.
+            spotlight:
+              visibility: show
+              categories:
+                - kpi
+                - sales
           total_amount_thousands:
             groups: ['Deal Amounts']
             description: The sum of deal amount for selected deals, shown in thousands
@@ -257,6 +272,20 @@ models:
               visibility: show
               categories:
                 - kpi
+          average_won_amount:
+            groups: ['Deal Amounts']
+            type: average
+            description: The average deal amount for won deals
+            format: '$#,##0'
+            filters:
+              - stage: 'Won'
+            ai_hint: |
+              CloseRate Kevin: Use average_won_amount to measure average won deal size.
+              Compare across segments, industries, or time periods to spot changes in deal quality.
+            spotlight:
+              visibility: show
+              categories:
+                - sales
           max_won_deal_amount:
             groups: ['Deal Amounts']
             type: max

--- a/models/demo/leads.yml
+++ b/models/demo/leads.yml
@@ -179,6 +179,13 @@ models:
                 visibility: show
                 categories:
                   - sales
+            deal_count:
+              type: count_distinct
+              description: "The number of unique deals associated with leads"
+              spotlight:
+                visibility: show
+                categories:
+                  - sales
       - name: lead_source
         description: "The name of the source which drew in the lead"
         meta:
@@ -208,6 +215,15 @@ models:
         meta:
           dimension:
             type: string
+          metrics:
+            unique_campaign_count:
+              type: count_distinct
+              description: "The unique number of marketing campaigns"
+              spotlight:
+                visibility: show
+                categories:
+                  - leads
+                  - marketing
       - name: utm_medium
         description: "UTM medium used for the lead (e.g., email, cpc, social)"
         meta:


### PR DESCRIPTION
## Summary

The SaaS Demo validator (Aug 11, 1:19 PM) flagged 14 errors, all tracing back to 5 metrics missing from the deployed explores. These charts/dashboards are confirmed valid content, so this PR restores every missing metric in the dbt YAML.

| Validation error | Fix |
|---|---|
| `deals_total_open_amount` no longer exists ("Open pipeline amount" tile, Sales Pipeline dashboard) | New `total_open_amount` sum metric on `deals.amount`, filtered to open stages (`New`, `Qualified`, `PoC`, `Negotiation`) |
| `deals_average_won_amount` no longer exists ("Average won deal size" tile, Sales Pipeline dashboard) | New `average_won_amount` average metric on `deals.amount`, filtered to `Won` |
| `leads.deal_count` not found in explore `lead_geography` (metric + sort + global filter on "Total Deals Per Country Bubble Chart") | New `deal_count` count_distinct metric on `leads.deal_id` (reaches `lead_geography` via its join to `leads`) |
| `leads_unique_campaign_count` no longer exists ("How many unique campaigns does each industry have?") | New `unique_campaign_count` count_distinct metric on `leads.campaign_name` |
| `activities_avg_activities_per_lead` no longer exists ("Avg Activities per Lead") | The model-level `metrics:` block in `activities.yml` sat **outside** `meta:` (since its first commit), so Lightdash never parsed it. Moved it under `meta:` |

## Details on the activities.yml fix

- `avg_activities_per_lead` divides two metrics, so its type is corrected from `average` to `number` (a derived metric, same pattern as `leads.conversion_rate`) — wrapping it in another `AVG()` would produce nested aggregates and fail in BigQuery.
- Its dependency `lead_id_total_leads` was also malformed (defined directly under column `meta:` instead of under `metrics:`) — now properly nested.
- The `deal_id` column had a copy-pasted block also named `lead_id_total_leads` (labeled "Total Deals"). Nesting it unchanged would have collided with the real `lead_id_total_leads`, so it's renamed `deal_id_total_deals`. It was never parsed before, so nothing can reference the old name.

## Notes

- None of these metric names ever existed in this repo's git history — the charts were built against metrics that only lived in the deployed project. Definitions here are authored to match each chart's intent, following the file's existing conventions (groups, formats, spotlight, ai_hints).
- The stage filter for `total_open_amount` intentionally excludes the two stray seed rows (`Proposal`, `Closed Won`), consistent with the existing `stage_order` dimension.
- One validation row showed a global filter saved as bare `deal_count` (no table prefix) on the bubble chart's dashboard. If that filter doesn't self-heal after deploy, it may need a one-time remap in the UI.
- Not deployed — @toriwhaley runs `lightdash deploy` manually after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)