### PR TITLE
Fix Lightdash validation errors: restore min_call_time, tag lod_examples

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -24,6 +24,7 @@ models:
     lod_examples:
       +meta:
         group_label: lod
+      +tags: lightdash_demo
     pop_example:
       +meta:
         group_label: pop

--- a/models/demo/activities.yml
+++ b/models/demo/activities.yml
@@ -165,3 +165,8 @@ models:
               label: Average call time
               description: "Average call time in seconds"
               groups: ['Call Metrics']
+            min_call_time:
+              type: min
+              label: Minimum call time
+              description: "Minimum call time in seconds"
+              groups: ['Call Metrics']


### PR DESCRIPTION
Clears all 22 errors in the Lightdash validator for the SaaS Demo project.

## Root cause

The project's dbt connection is GitHub-sourced with `selector: tag:lightdash_demo` on branch `main`. In `dbt_project.yml`, `demo`, `maps_examples`, and `pop_example` all carried that tag — **`lod_examples` did not**. So every GitHub-sourced deploy silently excluded the four `lod_*` models.

They weren't broken, they were never compiled: `GET /explores/lod_benchmark_demo` returns `404 — does not exist`, and no explore reports a compile error. That's why adding them to the project's model allow-list didn't help — that list can only filter explores that exist.

Confirmed by arithmetic: the deployed project had exactly 12 dbt explores (8 `demo` + 3 `maps_examples` + 1 `pop_example`) — precisely `tag:lightdash_demo`.

Ruled out: all four `lod_*` tables exist in both `lightdash_demo_saas` and `dbt_twhaley`, and the tables configuration already listed all 16 model names.

## Changes

- **`dbt_project.yml`** — add `+tags: lightdash_demo` to `lod_examples` so its explores survive GitHub-sourced deploys. Fixes 21 of 22 errors (the LOD Calcs dashboard plus its four charts).
- **`models/demo/activities.yml`** — restore the `min_call_time` metric. The chart "What is the minimum call time by month?" depends on `activities_min_call_time`, which only ever existed as an uncommitted working-tree edit and was never carried onto `main`.

## Note

The tag change only takes effect on a GitHub-sourced deploy. A local `lightdash deploy` compiles the whole project with no selector, so it would mask the issue. Merge and let the deploy run from `main` to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)